### PR TITLE
Fix building on Windows and Linux

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,10 +20,10 @@ The mod will expand late-game play as steel is the primary material used for its
 ## Building
 Set the VINTAGE_STORY environmental variable before loading or trying to build the project. The [wiki](https://wiki.vintagestory.at/index.php/Modding:Preparing_For_Code_Mods#Creating_an_Environment_Variable) has directions for setting the variable on Windows.
 
-The mod can be built with either Visual Studio or directly with msbuild.
+The mod can be built with either Visual Studio, Visual Studio Code, or directly with msbuild. It has been tested on Windows and Linux.
 
-### Visual Studio
-Load the solution file in the code\VintageEngineering directory with Visual Studio. Press F5 to launch Vintage Story in the debugger with the mod loaded.
+### Visual Studio or Visual Studio Code
+Load the solution in the code\VintageEngineering directory. Press F5 to launch Vintage Story in the debugger with the mod loaded.
 
 Press Ctrl + Shift + B to build the mod without starting the debugger.
 

--- a/Readme.md
+++ b/Readme.md
@@ -17,6 +17,22 @@ The mod will expand late-game play as steel is the primary material used for its
 - Electrical system, power generation using Coal and oil based combustion, then expanding into more modern power options (nuclear?).
 - Pipez-style system for moving goods and fluids around. At least I hope this won't crush FPS.
 
+## Building
+Set the VINTAGE_STORY environmental variable before loading or trying to build the project. The [wiki](https://wiki.vintagestory.at/index.php/Modding:Preparing_For_Code_Mods#Creating_an_Environment_Variable) has directions for setting the variable on Windows.
+
+The mod can be built with either Visual Studio or directly with msbuild.
+
+### Visual Studio
+Load the solution file in the code\VintageEngineering directory with Visual Studio. Press F5 to launch Vintage Story in the debugger with the mod loaded.
+
+Press Ctrl + Shift + B to build the mod without starting the debugger.
+
+### MSBuild
+Open a developer command prompt (one that has msbuild in the path). From the code\VintageEngineering directory, either run `msbuild` or `dotnet build`, depending on which is installed on your system.
+
+### Packaging
+After a successful build, the output will be placed in the mod directory. In order to distribute the mod, the contents of the mod directory must be manually zipped. Specifically the zip file should contain modinfo.json at the top level, rather than mod\modinfo.json.
+
 ## Help Is Welcome
 Immersive Engineering has had over 80 contributers, I know a project like this is just overwhelming for one person. So I will be more then welcoming of other contributions.
 

--- a/code/VintageEngineering/.vscode/launch.json
+++ b/code/VintageEngineering/.vscode/launch.json
@@ -15,13 +15,12 @@
             "osx": {
                 "program": "${env:VINTAGE_STORY}/Vintagestory"
             },
-            "preLaunchTask": "build",
+            "preLaunchTask": "build (Debug)",
             "args": [
-                // "--playStyle" , "preset-surviveandbuild",
-                // "--openWorld" , "modding test world",
                 "--tracelog",
                 "--addModPath",
-                "${workspaceFolder}/VintageEngineering/bin/Debug/Mods"
+                "${workspaceFolder}/../../",
+                "--openWorld=modtestworld"
             ],
             "console": "internalConsole",
             "stopAtEntry": false
@@ -37,25 +36,14 @@
             "osx": {
                 "program": "${env:VINTAGE_STORY}/VintagestoryServer"
             },
-            "preLaunchTask": "build",
+            "preLaunchTask": "build (Debug)",
             "args": [
                 "--tracelog",
                 "--addModPath",
-                "${workspaceFolder}/VintageEngineering/bin/Debug/Mods"
+                "${workspaceFolder}/../../"
             ],
             "console": "internalConsole",
             "stopAtEntry": false
-        },
-        {
-            "name": "CakeBuild",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build (Cake)",
-            "program": "${workspaceFolder}/CakeBuild/bin/Debug/net7.0/CakeBuild.dll",
-            "args": [],
-            "cwd": "${workspaceFolder}/CakeBuild",
-            "stopAtEntry": false,
-            "console": "internalConsole"
         }
     ]
 }

--- a/code/VintageEngineering/.vscode/tasks.json
+++ b/code/VintageEngineering/.vscode/tasks.json
@@ -2,37 +2,32 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "build",
+            "label": "build (Debug)",
+            "group": {
+              "kind": "build",
+              "isDefault": true
+            },
             "command": "dotnet",
             "type": "process",
             "args": [
                 "build",
                 "-c",
-                "Debug",
-                "${workspaceFolder}/VintageEngineering/VintageEngineering.csproj"
+                "Debug"
             ],
             "problemMatcher": "$msCompile"
         },
         {
-            "label": "package",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "run",
-                "--project",
-                "${workspaceFolder}/CakeBuild/CakeBuild.csproj"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "build (Cake)",
+            "label": "build (Release)",
+            "group": {
+              "kind": "build",
+              "isDefault": false
+            },
             "command": "dotnet",
             "type": "process",
             "args": [
                 "build",
                 "-c",
-                "Debug",
-                "${workspaceFolder}/CakeBuild/CakeBuild.csproj"
+                "Release"
             ],
             "problemMatcher": "$msCompile"
         }

--- a/code/VintageEngineering/Properties/launchSettings.json
+++ b/code/VintageEngineering/Properties/launchSettings.json
@@ -3,13 +3,13 @@
     "Client": {
       "commandName": "Executable",
       "executablePath": "$(VINTAGE_STORY)/Vintagestory.exe",
-      "commandLineArgs": "--tracelog --addModPath=\"C:\\_Programming\\Vintage\\VintageEngineering\" -o modtestworld",
+      "commandLineArgs": "--tracelog --addModPath=\"$(MSBuildProjectDirectory)\\..\\..\" -o modtestworld",
       "workingDirectory": "$(VINTAGE_STORY)"
     },
     "Server": {
       "commandName": "Executable",
       "executablePath": "$(VINTAGE_STORY)/VintagestoryServer.exe",
-      "commandLineArgs": "--tracelog --addModPath=\"C:\\_Programming\\Vintage\\VintageEngineering\" -o modtestworld",
+      "commandLineArgs": "--tracelog --addModPath=\"$(MSBuildProjectDirectory)\\..\\..\" -o modtestworld",
       "workingDirectory": "$(VINTAGE_STORY)"
     }
   }

--- a/code/VintageEngineering/VintageEngineering.csproj
+++ b/code/VintageEngineering/VintageEngineering.csproj
@@ -8,31 +8,31 @@
 
   <ItemGroup>
     <Reference Include="cairo-sharp">
-      <HintPath>..\..\..\..\..\Users\simtr\AppData\Roaming\Vintagestory\Lib\cairo-sharp.dll</HintPath>
+      <HintPath>$(VINTAGE_STORY)\Lib\cairo-sharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\..\..\Users\simtr\AppData\Roaming\Vintagestory\Lib\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(VINTAGE_STORY)\Lib\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="protobuf-net">
-      <HintPath>..\..\..\..\..\Users\simtr\AppData\Roaming\Vintagestory\Lib\protobuf-net.dll</HintPath>
+      <HintPath>$(VINTAGE_STORY)\Lib\protobuf-net.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VintagestoryAPI">
-      <HintPath>..\..\..\..\..\Users\simtr\AppData\Roaming\Vintagestory\VintagestoryAPI.dll</HintPath>
+      <HintPath>$(VINTAGE_STORY)\VintagestoryAPI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VintagestoryLib">
-      <HintPath>..\..\..\..\..\Users\simtr\AppData\Roaming\Vintagestory\VintagestoryLib.dll</HintPath>
+      <HintPath>$(VINTAGE_STORY)\VintagestoryLib.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VSEssentials">
-      <HintPath>..\..\..\..\..\Users\simtr\AppData\Roaming\Vintagestory\Mods\VSEssentials.dll</HintPath>
+      <HintPath>$(VINTAGE_STORY)\Mods\VSEssentials.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VSSurvivalMod">
-      <HintPath>..\..\..\..\..\Users\simtr\AppData\Roaming\Vintagestory\Mods\VSSurvivalMod.dll</HintPath>
+      <HintPath>$(VINTAGE_STORY)\Mods\VSSurvivalMod.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -53,7 +53,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="copy $(TargetDir)*.* C:\_Programming\Vintage\VintageEngineering\mod&#xD;&#xA;" />
+    <Exec Command="copy $(TargetDir)*.* $(MSBuildProjectDirectory)\..\..\mod" />
   </Target>
 
 </Project>

--- a/code/VintageEngineering/VintageEngineering.csproj
+++ b/code/VintageEngineering/VintageEngineering.csproj
@@ -53,7 +53,34 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="copy $(TargetDir)*.* $(MSBuildProjectDirectory)\..\..\mod" />
+    <!-- In a csproj, items are a kind of variable that can hold a filename
+         list. Setting an item is a way to evaluate a filename glob. Items are
+         read with the syntax: @(name).
+
+         Items can only be set inside of a ItemGroup element. Because this
+         ItemGroup is inside a Target, the items will be evaluated when the
+         target is run, instead of when the csproj is loaded. This is
+         important, because the target files (including the output dll) may
+         not exist when the csproj is first loaded.
+
+         This pattern is documented at
+         https://learn.microsoft.com/en-us/visualstudio/msbuild/copy-task?view=vs-2022.
+        -->
+
+    <ItemGroup>
+      <!-- The name of the item (kind of variable) is given in the element name.
+
+            Full syntax:
+            https://learn.microsoft.com/en-us/visualstudio/msbuild/item-element-msbuild?view=vs-2022
+
+          -->
+      <TargetFiles Include="$(TargetDir)\*.*" />
+    </ItemGroup>
+    <Copy
+      SourceFiles="@(TargetFiles)"
+      DestinationFolder="$(MSBuildProjectDirectory)\..\..\mod"
+      SkipUnchangedFiles="true"
+    />
   </Target>
 
 </Project>


### PR DESCRIPTION
This PR
1. Fixes the hard coded paths in the build rules
2. Makes the build platform independent
3. Fixes VSCode rules.
4. Adds directions for building it.

I tested with Visual Studio Community Edition on Windows and Visual Studio Code on Linux.

Depending on how you feel about changing the build process, these are some further improvements I could make in the next PR:
1. Move the solution to the top directory, because it's a bit confusing and non-standard to find it in the code/VintageEngineering directory.
2. Use a separate modpath and originpath when running VS in the debugger, in order to avoid copying the dll file to the mod folder. This will also give a cleaner separation between source files and generated files.
3. Create a build task to package a zip, because it's tedious to remove all of the intermediate files out of the mod directory (such as the deps.json and nupkg files) and zip it. This mostly depends on step #2, because the mod folder should be clean before trying to package it.