### PR TITLE
Add machine recipes to the handbook

### DIFF
--- a/code/VintageEngineering/Electrical/Systems/Catenary/WiredBlock.cs
+++ b/code/VintageEngineering/Electrical/Systems/Catenary/WiredBlock.cs
@@ -10,7 +10,7 @@ namespace VintageEngineering.Electrical.Systems.Catenary
 {
     /// <summary>
     /// Base object for a generic wire connectable block
-    /// <br>Impliments IWireAnchor</br>
+    /// <br>Implements IWireAnchor</br>
     /// </summary>
     public abstract class WiredBlock : Block, IWireAnchor
     {

--- a/code/VintageEngineering/Patches/CollectibleBehaviorHandbookTextAndExtraInfoPatch.cs
+++ b/code/VintageEngineering/Patches/CollectibleBehaviorHandbookTextAndExtraInfoPatch.cs
@@ -1,0 +1,118 @@
+using HarmonyLib;
+using System.Collections.Generic;
+using Vintagestory.API.Client;
+using Vintagestory.API.Common;
+using Vintagestory.GameContent;
+
+namespace VintageEngineering;
+
+// Disable warnings about addCreatedByInfoPrefix not starting with a capital letter.
+#pragma warning disable IDE1006
+
+/// <summary>
+/// Publicly exposes some formatting methods from <see cref="CollectibleBehaviorHandbookTextAndExtraInfo/>
+/// </summary>
+public class CollectibleBehaviorHandbookTextAndExtraInfoAccessor : CollectibleBehaviorHandbookTextAndExtraInfo
+{
+    public CollectibleBehaviorHandbookTextAndExtraInfoAccessor() : base(null)
+    {
+    }
+
+    public static new void AddHeading(List<RichTextComponentBase> components, ICoreClientAPI capi, string heading, ref bool haveText)
+    {
+        CollectibleBehaviorHandbookTextAndExtraInfo.AddHeading(components, capi, heading, ref haveText);
+    }
+
+    public new void AddSubHeading(List<RichTextComponentBase> components, ICoreClientAPI capi, ActionConsumable<string> openDetailPageFor, string subheading, string detailpage)
+    {
+        base.AddSubHeading(components, capi, openDetailPageFor, subheading, detailpage);
+    }
+
+    public new const int SmallPadding = CollectibleBehaviorHandbookTextAndExtraInfo.SmallPadding;
+    public new const int TinyPadding = CollectibleBehaviorHandbookTextAndExtraInfo.TinyPadding;
+    public new const int MarginBottom = CollectibleBehaviorHandbookTextAndExtraInfo.MarginBottom;
+}
+
+[HarmonyPatch(typeof(CollectibleBehaviorHandbookTextAndExtraInfo))]
+class CollectibleBehaviorHandbookTextAndExtraInfoPatch
+{
+    static readonly CollectibleBehaviorHandbookTextAndExtraInfoAccessor accessor = new();
+
+    public const int SmallPadding = CollectibleBehaviorHandbookTextAndExtraInfoAccessor.SmallPadding;
+    public const int TinyPadding = CollectibleBehaviorHandbookTextAndExtraInfoAccessor.TinyPadding;
+    public const int MarginBottom = CollectibleBehaviorHandbookTextAndExtraInfoAccessor.MarginBottom;
+
+    public static void AddHeading(List<RichTextComponentBase> components, ICoreClientAPI capi, string heading, ref bool haveText)
+    {
+        CollectibleBehaviorHandbookTextAndExtraInfoAccessor.AddHeading(components, capi, heading, ref haveText);
+    }
+
+    public static void AddSubHeading(List<RichTextComponentBase> components, ICoreClientAPI capi, ActionConsumable<string> openDetailPageFor, string subheading, string detailpage)
+    {
+        accessor.AddSubHeading(components, capi, openDetailPageFor, subheading, detailpage);
+    }
+
+    /// <summary>
+    /// Allow adding more components to the handbook page before the "Created by" section.
+    /// </summary>
+    /// <param name="stack">Item that the page is being generated for.</param>
+    /// <param name="components">The GUI elements added to the page so far. Put any new elements at the end of this list.</param>
+    /// <param name="haveText">True if a margin should be added before the next element. Generally this should be set to true after anything is added to <paramref name="components"/></param>
+    public delegate void AddProcessesIntoInfoDelegate(ICoreClientAPI capi, ActionConsumable<string> openDetailPageFor, ItemStack stack, List<RichTextComponentBase> components, ref bool haveText);
+
+    /// <summary>
+    /// Allow adding more components to the handbook page inside the "Created by" section.
+    /// </summary>
+    /// <param name="allStacks">Array of all known items and blocks. This is useful for searching for checking attributes on all items to see if they somehow transform into <paramref name="stack"/></param>
+    /// <param name="stack">Item that the page is being generated for.</param>
+    /// <param name="components">The GUI elements added by delegates to the created by section so far. If this is null, then initialize it to a non-null list before adding elements. Otherwise, add new elements to the existing list.</param>
+    public delegate void AddCreatedByInfoDelegate(ICoreClientAPI capi, ItemStack[] allStacks, ActionConsumable<string> openDetailPageFor, ItemStack stack, ref List<RichTextComponentBase> components);
+
+    public static AddProcessesIntoInfoDelegate ProcessesInto;
+    public static AddCreatedByInfoDelegate CreatedBy;
+
+    [HarmonyPrefix]
+    [HarmonyPatch("addCreatedByInfo")]
+    static void addCreatedByInfoPrefix(out int __state, ICoreClientAPI capi,
+                                       ItemStack[] allStacks,
+                                       ActionConsumable<string> openDetailPageFor,
+                                       ItemStack stack,
+                                       List<RichTextComponentBase> components,
+                                       float marginTop, ref bool haveText)
+    {
+        ProcessesInto?.Invoke(capi, openDetailPageFor, stack, components, ref haveText);
+        // Remember how many elements are in the components list before invoking the original method.
+        __state = components.Count;
+    }
+
+    [HarmonyPostfix]
+    [HarmonyPatch("addCreatedByInfo")]
+    static void addCreatedByInfoPostfix(
+        int __state, ref bool __result, ICoreClientAPI capi,
+        ItemStack[] allStacks, ActionConsumable<string> openDetailPageFor,
+        ItemStack stack, List<RichTextComponentBase> components, float marginTop,
+        bool haveText)
+    {
+        List<RichTextComponentBase> delegateAdded = null;
+        CreatedBy?.Invoke(capi, allStacks, openDetailPageFor, stack, ref delegateAdded);
+        if ((delegateAdded?.Count ?? 0) != 0)
+        {
+            // __state contains the number of components in the list at the end of the prefix method. If the number of
+            // elements is the same, then the original method did not add a "Created by" heading.
+            if (components.Count == __state)
+            {
+                AddHeading(components, capi, "Created by", ref haveText);
+                components.Add(new ClearFloatTextComponent(capi, TinyPadding + 1));
+            }
+            else
+            {
+                components.Add(new ClearFloatTextComponent(capi, SmallPadding));
+            }
+            components.AddRange(delegateAdded);
+            // Now items were definitely added to <paramref name="components"/>
+            __result = true;
+        }
+    }
+}
+
+#pragma warning restore IDE1006

--- a/code/VintageEngineering/RecipeSystem/Recipes/IVEMachineRecipeBase.cs
+++ b/code/VintageEngineering/RecipeSystem/Recipes/IVEMachineRecipeBase.cs
@@ -74,5 +74,28 @@ namespace VintageEngineering.RecipeSystem.Recipes
         /// Typically of type VERecipeVariableOuput for VE variable-output recipes.
         /// </summary>
         IRecipeOutput[] Outputs { get; }
+
+        /// <summary>
+        /// Determines if the given item stack matches the recipe ingredient.
+        /// </summary>
+        /// <param name="index">A valid index in <see cref="Ingredients"/></param>
+        /// <param name="inputStack">The stack to match against the ingredient</param>
+        /// <param name="checkStacksize">Whether the stack size (number of items) should be considered in the comparison</param>
+        /// <returns>true if the inputStack matches</returns>
+        bool SatisfiesAsIngredient(int index, ItemStack inputStack, bool checkStacksize = true);
+
+        /// <summary>
+        ///  Gets the resolved item corresponding to an input ingredient.
+        /// </summary>
+        /// <param name="index">A valid index in <see cref="Ingredients"/></param>
+        /// <returns>resolved item, or null if the ingredient is a wildcard</returns>
+        ItemStack GetResolvedInput(int index);
+
+        /// <summary>
+        ///  Gets the resolved item corresponding to a recipe output.
+        /// </summary>
+        /// <param name="index">A valid index in <see cref="Outputs"/></param>
+        /// <returns>resolved item</returns>
+        ItemStack GetResolvedOutput(int index);
     }
 }

--- a/code/VintageEngineering/RecipeSystem/Recipes/RecipeAlloyOven.cs
+++ b/code/VintageEngineering/RecipeSystem/Recipes/RecipeAlloyOven.cs
@@ -73,6 +73,18 @@ namespace VintageEngineering.RecipeSystem.Recipes
             }
         }
 
+        public bool SatisfiesAsIngredient(int index, ItemStack inputStack, bool checkStacksize = true) {
+            return Ingredients[index].SatisfiesAsIngredient(inputStack, checkStacksize);
+        }
+
+        public ItemStack GetResolvedInput(int index) {
+            return Ingredients[index].ResolvedItemstack;
+        }
+
+        public ItemStack GetResolvedOutput(int index) {
+            return Outputs[index].ResolvedItemstack;
+        }
+
         public RecipeAlloyOven Clone()
         {
             throw new NotImplementedException();

--- a/code/VintageEngineering/RecipeSystem/Recipes/RecipeCokeOven.cs
+++ b/code/VintageEngineering/RecipeSystem/Recipes/RecipeCokeOven.cs
@@ -72,6 +72,18 @@ namespace VintageEngineering.RecipeSystem.Recipes
             }
         }
 
+        public bool SatisfiesAsIngredient(int index, ItemStack inputStack, bool checkStacksize = true) {
+            return Ingredients[index].SatisfiesAsIngredient(inputStack, checkStacksize);
+        }
+
+        public ItemStack GetResolvedInput(int index) {
+            return Ingredients[index].ResolvedItemstack;
+        }
+
+        public ItemStack GetResolvedOutput(int index) {
+            return Outputs[index].ResolvedItemstack;
+        }
+
         public RecipeCokeOven Clone()
         {
             throw new NotImplementedException();

--- a/code/VintageEngineering/RecipeSystem/Recipes/RecipeCrusher.cs
+++ b/code/VintageEngineering/RecipeSystem/Recipes/RecipeCrusher.cs
@@ -67,28 +67,26 @@ namespace VintageEngineering.RecipeSystem.Recipes
             }
         }
 
+        public bool SatisfiesAsIngredient(int index, ItemStack inputStack, bool checkStacksize = true)
+        {
+            return Ingredients[index].SatisfiesAsIngredient(inputStack, checkStacksize);
+        }
+
+        public ItemStack GetResolvedInput(int index)
+        {
+            return Ingredients[index].ResolvedItemstack;
+        }
+
+        public ItemStack GetResolvedOutput(int index)
+        {
+            return Outputs[index].ResolvedItemstack;
+        }
+
         public bool Matches(ItemSlot ingredient, ItemSlot requireslot = null)
         {
             if (ingredient.Empty) return false; // no ingredient to even check, bounce
 
-            if (Ingredients[0].ResolvedItemstack != null)
-            {
-                // Satisfies call ignores fields not needed to test for equality, like stacksize.
-                if (!Ingredients[0].ResolvedItemstack.Satisfies(ingredient.Itemstack))
-                {
-                    if (!Ingredients[0].SatisfiesAsIngredient(ingredient.Itemstack, true))
-                    {
-                        return false;
-                    }
-                    return false;
-                }
-                // check stack sizes... 
-                if (ingredient.Itemstack.StackSize < Ingredients[0].ResolvedItemstack.StackSize) return false;
-            }
-            else
-            {
-                if (!Ingredients[0].SatisfiesAsIngredient(ingredient.Itemstack, true)) return false;
-            }
+            if (!Ingredients[0].SatisfiesAsIngredient(ingredient.Itemstack, true)) return false;
 
             if (Requires != null) // if this recipe requires something, we need to check for it in the requires slot
             {

--- a/code/VintageEngineering/RecipeSystem/Recipes/RecipeExtruder.cs
+++ b/code/VintageEngineering/RecipeSystem/Recipes/RecipeExtruder.cs
@@ -76,6 +76,19 @@ namespace VintageEngineering.RecipeSystem.Recipes
             }
         }
 
+        public bool SatisfiesAsIngredient(int index, ItemStack inputStack, bool checkStacksize = true)
+        {
+            return Ingredients[index].SatisfiesAsIngredient(inputStack, checkStacksize);
+        }
+
+        public ItemStack GetResolvedInput(int index) {
+            return Ingredients[index].ResolvedItemstack;
+        }
+
+        public ItemStack GetResolvedOutput(int index) {
+            return Outputs[index].ResolvedItemstack;
+        }
+
         /// <summary>
         /// Checks the validity of given ingredient and "requires" item to this recipe.<br/>        
         /// </summary>        
@@ -86,24 +99,7 @@ namespace VintageEngineering.RecipeSystem.Recipes
         {
             if (ingredient.Empty) return false; // no ingredient to even check, bounce
 
-            if (Ingredients[0].ResolvedItemstack != null)
-            {
-                // Satisfies call ignores fields not needed to test for equality, like stacksize.
-                if (!Ingredients[0].ResolvedItemstack.Satisfies(ingredient.Itemstack))
-                {
-                    if (!Ingredients[0].SatisfiesAsIngredient(ingredient.Itemstack, true))
-                    {
-                        return false;
-                    }
-                    return false;
-                }
-                // check stack sizes... 
-                if (ingredient.Itemstack.StackSize < Ingredients[0].ResolvedItemstack.StackSize) return false;
-            }
-            else
-            {
-                if (!Ingredients[0].SatisfiesAsIngredient(ingredient.Itemstack, true)) return false;
-            }
+            if (!Ingredients[0].SatisfiesAsIngredient(ingredient.Itemstack, true)) return false;
 
             if (Requires != null) // if this recipe requires something, we need to check for it in the requires slot
             {

--- a/code/VintageEngineering/RecipeSystem/Recipes/RecipeGrinder.cs
+++ b/code/VintageEngineering/RecipeSystem/Recipes/RecipeGrinder.cs
@@ -70,6 +70,19 @@ namespace VintageEngineering.RecipeSystem.Recipes
             }
         }
 
+        public bool SatisfiesAsIngredient(int index, ItemStack inputStack, bool checkStacksize = true)
+        {
+            return Ingredients[index].SatisfiesAsIngredient(inputStack, checkStacksize);
+        }
+
+        public ItemStack GetResolvedInput(int index) {
+            return Ingredients[index].ResolvedItemstack;
+        }
+
+        public ItemStack GetResolvedOutput(int index) {
+            return Outputs[index].ResolvedItemstack;
+        }
+
         public RecipeGrinder Clone()
         {
             throw new NotImplementedException();

--- a/code/VintageEngineering/RecipeSystem/Recipes/RecipeKiln.cs
+++ b/code/VintageEngineering/RecipeSystem/Recipes/RecipeKiln.cs
@@ -68,6 +68,19 @@ namespace VintageEngineering.RecipeSystem.Recipes
             }
         }
 
+        public bool SatisfiesAsIngredient(int index, ItemStack inputStack, bool checkStacksize = true)
+        {
+            return Ingredients[index].SatisfiesAsIngredient(inputStack, checkStacksize);
+        }
+
+        public ItemStack GetResolvedInput(int index) {
+            return Ingredients[index].ResolvedItemstack;
+        }
+
+        public ItemStack GetResolvedOutput(int index) {
+            return Outputs[index].ResolvedItemstack;
+        }
+
         public RecipeKiln Clone()
         {
             CraftingRecipeIngredient[] cloned = new CraftingRecipeIngredient[Ingredients.Length];
@@ -146,24 +159,7 @@ namespace VintageEngineering.RecipeSystem.Recipes
         {
             if (ingredient.Empty) return false; // no ingredient to even check, bounce
 
-            if (Ingredients[0].ResolvedItemstack != null)
-            {
-                // Satisfies call ignores fields not needed to test for equality, like stacksize.
-                if (!Ingredients[0].ResolvedItemstack.Satisfies(ingredient.Itemstack))
-                {
-                    if (!Ingredients[0].SatisfiesAsIngredient(ingredient.Itemstack, true))
-                    {
-                        return false;
-                    }
-                    return false;
-                }
-                // check stack sizes... 
-                if (ingredient.Itemstack.StackSize < Ingredients[0].ResolvedItemstack.StackSize) return false;
-            }
-            else
-            {
-                if (!Ingredients[0].SatisfiesAsIngredient(ingredient.Itemstack, true)) return false;
-            }
+            if (!Ingredients[0].SatisfiesAsIngredient(ingredient.Itemstack, true)) return false;
             return true;
         }
         public bool Resolve(IWorldAccessor world, string sourceForErrorLogging)

--- a/code/VintageEngineering/RecipeSystem/Recipes/RecipeLogSplitter.cs
+++ b/code/VintageEngineering/RecipeSystem/Recipes/RecipeLogSplitter.cs
@@ -71,6 +71,19 @@ namespace VintageEngineering.RecipeSystem.Recipes
             }
         }
 
+        public bool SatisfiesAsIngredient(int index, ItemStack inputStack, bool checkStacksize = true)
+        {
+            return Ingredients[index].SatisfiesAsIngredient(inputStack, checkStacksize);
+        }
+
+        public ItemStack GetResolvedInput(int index) {
+            return Ingredients[index].ResolvedItemstack;
+        }
+
+        public ItemStack GetResolvedOutput(int index) {
+            return Outputs[index].ResolvedItemstack;
+        }
+
         /// <summary>
         /// Checks the validity of given ingredient.<br/>        
         /// </summary>        
@@ -80,24 +93,7 @@ namespace VintageEngineering.RecipeSystem.Recipes
         {
             if (_ingredient.Empty) return false; // no ingredient to even check, bounce
             
-            if (Ingredients[0].ResolvedItemstack != null)
-            {
-                // Satisfies call ignores fields not needed to test for equality, like stacksize.
-                if (!Ingredients[0].ResolvedItemstack.Satisfies(_ingredient.Itemstack))
-                {
-                    if (!Ingredients[0].SatisfiesAsIngredient(_ingredient.Itemstack, true))
-                    {
-                        return false;
-                    }
-                    return false;
-                }
-                // check stack sizes... 
-                if (_ingredient.Itemstack.StackSize < Ingredients[0].ResolvedItemstack.StackSize) return false;
-            }
-            else
-            {
-                if (!Ingredients[0].SatisfiesAsIngredient(_ingredient.Itemstack, true)) return false;
-            }
+            if (!Ingredients[0].SatisfiesAsIngredient(_ingredient.Itemstack, true)) return false;
             return true;
         }
 

--- a/code/VintageEngineering/RecipeSystem/Recipes/RecipeMetalPress.cs
+++ b/code/VintageEngineering/RecipeSystem/Recipes/RecipeMetalPress.cs
@@ -76,6 +76,19 @@ namespace VintageEngineering.RecipeSystem.Recipes
             }
         }
 
+        public bool SatisfiesAsIngredient(int index, ItemStack inputStack, bool checkStacksize = true)
+        {
+            return Ingredients[index].SatisfiesAsIngredient(inputStack, checkStacksize);
+        }
+
+        public ItemStack GetResolvedInput(int index) {
+            return Ingredients[index].ResolvedItemstack;
+        }
+
+        public ItemStack GetResolvedOutput(int index) {
+            return Outputs[index].ResolvedItemstack;
+        }
+
         public RecipeMetalPress Clone()
         {
             CraftingRecipeIngredient[] cloned = new CraftingRecipeIngredient[Ingredients.Length];
@@ -114,25 +127,7 @@ namespace VintageEngineering.RecipeSystem.Recipes
         {
             if (ingredient.Empty) return false; // no ingredient to even check, bounce
 
-            if (Ingredients[0].ResolvedItemstack != null)
-            {
-                // Satisfies call ignores fields not needed to test for equality, like stacksize.
-                if (!Ingredients[0].ResolvedItemstack.Satisfies(ingredient.Itemstack))
-                {
-                    if (!Ingredients[0].SatisfiesAsIngredient(ingredient.Itemstack, true))
-                    {
-                        return false;
-                    }
-                    return false; 
-                }
-                //if (!ingredient.Itemstack.Satisfies(Ingredients[0].ResolvedItemstack)) return false;
-                // check stack sizes... 
-                if (ingredient.Itemstack.StackSize < Ingredients[0].ResolvedItemstack.StackSize) return false;
-            }
-            else
-            {
-                if (!Ingredients[0].SatisfiesAsIngredient(ingredient.Itemstack, true)) return false;
-            }
+            if (!Ingredients[0].SatisfiesAsIngredient(ingredient.Itemstack, true)) return false;
 
             if (Requires != null) // if this recipe requires something, we need to check for it in the requires slot
             {

--- a/code/VintageEngineering/RecipeSystem/Recipes/RecipeMixer.cs
+++ b/code/VintageEngineering/RecipeSystem/Recipes/RecipeMixer.cs
@@ -80,6 +80,19 @@ namespace VintageEngineering.RecipeSystem.Recipes
             }
         }
 
+        public bool SatisfiesAsIngredient(int index, ItemStack inputStack, bool checkStacksize = true)
+        {
+            return Ingredients[index].SatisfiesAsIngredient(inputStack, checkStacksize);
+        }
+
+        public ItemStack GetResolvedInput(int index) {
+            return Ingredients[index].ResolvedItemstack;
+        }
+
+        public ItemStack GetResolvedOutput(int index) {
+            return Outputs[index].ResolvedItemstack;
+        }
+
         public RecipeMixer Clone()
         {
             BarrelRecipeIngredient[] _ingredients = new BarrelRecipeIngredient[Ingredients.Length];

--- a/code/VintageEngineering/RecipeSystem/Recipes/RecipeSawMill.cs
+++ b/code/VintageEngineering/RecipeSystem/Recipes/RecipeSawMill.cs
@@ -71,6 +71,19 @@ namespace VintageEngineering.RecipeSystem.Recipes
             }
         }
 
+        public bool SatisfiesAsIngredient(int index, ItemStack inputStack, bool checkStacksize = true)
+        {
+            return Ingredients[index].SatisfiesAsIngredient(inputStack, checkStacksize);
+        }
+
+        public ItemStack GetResolvedInput(int index) {
+            return Ingredients[index].ResolvedItemstack;
+        }
+
+        public ItemStack GetResolvedOutput(int index) {
+            return Outputs[index].ResolvedItemstack;
+        }
+
         /// <summary>
         /// Checks the validity of given ingredient and "requires" item to this recipe.<br/>        
         /// </summary>        
@@ -81,24 +94,7 @@ namespace VintageEngineering.RecipeSystem.Recipes
         {
             if (ingredient.Empty) return false; // no ingredient to even check, bounce
 
-            if (Ingredients[0].ResolvedItemstack != null)
-            {
-                // Satisfies call ignores fields not needed to test for equality, like stacksize.
-                if (!Ingredients[0].ResolvedItemstack.Satisfies(ingredient.Itemstack))
-                {
-                    if (!Ingredients[0].SatisfiesAsIngredient(ingredient.Itemstack, true))
-                    {
-                        return false;
-                    }
-                    return false;
-                }
-                // check stack sizes... 
-                if (ingredient.Itemstack.StackSize < Ingredients[0].ResolvedItemstack.StackSize) return false;
-            }
-            else
-            {
-                if (!Ingredients[0].SatisfiesAsIngredient(ingredient.Itemstack, true)) return false;
-            }
+            if (!Ingredients[0].SatisfiesAsIngredient(ingredient.Itemstack, true)) return false;
 
             if (Requires != null) // if this recipe requires something, we need to check for it in the requires slot
             {

--- a/code/VintageEngineering/RecipeSystem/VERecipeRegistrySystem.cs
+++ b/code/VintageEngineering/RecipeSystem/VERecipeRegistrySystem.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using VintageEngineering.RecipeSystem.Recipes;
+using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 using Vintagestory.API.Server;
@@ -53,6 +56,8 @@ namespace VintageEngineering.RecipeSystem
         /// </summary>
         public List<RecipeAlloyOven>    AlloyOvenRecipes = new List<RecipeAlloyOven>();
 
+        private readonly Dictionary<string, List<Block>> recipeMachines = new();
+
         public override double ExecuteOrder()
         {
             return 0.6;
@@ -66,14 +71,21 @@ namespace VintageEngineering.RecipeSystem
         public override void Start(ICoreAPI api)
         {
             this.MetalPressRecipes = api.RegisterRecipeRegistry<RecipeRegistryGeneric<RecipeMetalPress>>("vemetalpressrecipes").Recipes;
+            AddRecipesToHandbook(api, this.MetalPressRecipes, "metalpress", "vinteng:Presses into", "vinteng:Pressing");
             this.LogSplitterRecipes = api.RegisterRecipeRegistry<RecipeRegistryGeneric<RecipeLogSplitter>>("velogsplitterrecipes").Recipes;
+            AddRecipesToHandbook(api, this.LogSplitterRecipes, "logsplitter", "vinteng:Splits into", "vinteng:Splitting");
             this.SawMillRecipes = api.RegisterRecipeRegistry<RecipeRegistryGeneric<RecipeSawMill>>("vesawmillrecipes").Recipes;
+            AddRecipesToHandbook(api, this.SawMillRecipes, "sawmill", "vinteng:Saws into", "vinteng:Sawing");
 
             this.ExtruderRecipes = api.RegisterRecipeRegistry<RecipeRegistryGeneric<RecipeExtruder>>("veextruderrecipes").Recipes;
+            AddRecipesToHandbook(api, this.ExtruderRecipes, "extruder", "vinteng:Extrudes into", "vinteng:Extruding");
 
             this.CrusherRecipes = api.RegisterRecipeRegistry<RecipeRegistryGeneric<RecipeCrusher>>("vecrusherrecipes").Recipes;
+            AddRecipesToHandbook(api, this.CrusherRecipes, "crusher", "vinteng:Industrially crushes into", "vinteng:Industrially crushing");
             this.KilnRecipes = api.RegisterRecipeRegistry<RecipeRegistryGeneric<RecipeKiln>>("vekilnrecipes").Recipes;
+            AddRecipesToHandbook(api, this.KilnRecipes, "kiln", "vinteng:Industrially fires into", "vinteng:Industrially firing");
             this.MixerRecipes = api.RegisterRecipeRegistry<RecipeRegistryGeneric<RecipeMixer>>("vemixerrecipes").Recipes;
+            AddRecipesToHandbook(api, this.MixerRecipes, "mixer", "vinteng:Industrially mixes into", "vinteng:Industrially mixing");
         }
 
         public override void AssetsLoaded(ICoreAPI api)
@@ -82,7 +94,7 @@ namespace VintageEngineering.RecipeSystem
             if (sapi == null)
             {
                 return;
-            }                        
+            }
         }
 
         public void RegisterMetalPressRecipe(RecipeMetalPress metalPressRecipe)
@@ -183,6 +195,217 @@ namespace VintageEngineering.RecipeSystem
             }
             recipeAlloyOven.RecipeID = AlloyOvenRecipes.Count + 1;
             this.AlloyOvenRecipes.Add(recipeAlloyOven);
+        }
+
+        /// <summary>
+        /// Register the machine as capable of handling recipes of a given type
+        /// </summary>
+        /// <param name="recipeType">The type of recipe the machine can handle</param>
+        /// <param name="machine">The machine that processes recipes</param>
+        public void RegisterRecipeMachine(string recipeType, Block machine)
+        {
+            if (!recipeMachines.TryGetValue(recipeType, out List<Block> blocks))
+            {
+                blocks = new();
+                recipeMachines.Add(recipeType, blocks);
+            }
+            blocks.Add(machine);
+        }
+
+        /// <summary>
+        /// Finds all recipe outputs that take the ingredient, ignoring stack attributes.
+        /// </summary>
+        /// <param name="input">the input ingredient to search for</param>
+        /// <returns>A dictionary of recipe outputs. The outputs are grouped in the dictionary their recipe name.</returns>
+        private static IReadOnlyDictionary<AssetLocation, List<ItemStack>>
+        GetOutputsForIngredient<T>(IReadOnlyList<IVEMachineRecipeBase<T>> recipes, ItemStack input)
+        {
+            Dictionary<AssetLocation, List<ItemStack>> result = null;
+            foreach (IVEMachineRecipeBase<T> recipe in recipes)
+            {
+                for (int inputIndex = 0; inputIndex < recipe.Ingredients.Length; ++inputIndex)
+                {
+                    if (recipe.SatisfiesAsIngredient(inputIndex, input, false))
+                    {
+                        for (int outputIndex = 0; outputIndex < recipe.Outputs.Length; ++outputIndex)
+                        {
+                            result ??= new();
+                            if (!result.TryGetValue(recipe.Name,
+                                                    out List<ItemStack> resultList))
+                            {
+                                resultList = new();
+                                result.Add(recipe.Name, resultList);
+                            }
+                            resultList.Add(recipe.GetResolvedOutput(outputIndex));
+                        }
+                        break;
+                    }
+                }
+            }
+            return (IReadOnlyDictionary<AssetLocation, List<ItemStack>>)result ??
+                   ImmutableDictionary<AssetLocation, List<ItemStack>>.Empty;
+        }
+
+        /// <summary>
+        /// Finds the ingredients for any recipes that produces the output, ignoring stack attributes.
+        /// </summary>
+        /// <param name="output">the recipe output to search for</param>
+        /// <param name="allStacks">every resolved item</param>
+        /// <returns>A dictionary of recipe ingredients. The ingredients are grouped in the dictionary their recipe name.</returns>
+        private static IReadOnlyDictionary<AssetLocation, List<ItemStack>>
+        GetIngredientsForOutput<T>(ICoreClientAPI capi, IReadOnlyList<IVEMachineRecipeBase<T>> recipes, ItemStack output, ItemStack[] allStacks)
+        {
+            Dictionary<AssetLocation, List<ItemStack>> result = null;
+            foreach (IVEMachineRecipeBase<T> recipe in recipes)
+            {
+                for (int outputIndex = 0; outputIndex < recipe.Outputs.Length; ++outputIndex)
+                {
+                    if (recipe.GetResolvedOutput(outputIndex).Equals(
+                            capi.World, output, GlobalConstants.IgnoredStackAttributes))
+                    {
+                        for (int inputIndex = 0; inputIndex < recipe.Ingredients.Length; ++inputIndex)
+                        {
+                            result ??= new();
+                            if (!result.TryGetValue(recipe.Name,
+                                                    out List<ItemStack> resultList))
+                            {
+                                resultList = new();
+                                result.Add(recipe.Name, resultList);
+                            }
+                            ItemStack resolved = recipe.GetResolvedInput(inputIndex);
+                            if (resolved != null)
+                            {
+                                resultList.Add(recipe.GetResolvedInput(inputIndex));
+                            }
+                            else
+                            {
+                                foreach (ItemStack item in allStacks)
+                                {
+                                    if (recipe.SatisfiesAsIngredient(inputIndex, item, false))
+                                    {
+                                        resultList.Add(item);
+                                    }
+                                }
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+            return (IReadOnlyDictionary<AssetLocation, List<ItemStack>>)result ??
+                   ImmutableDictionary<AssetLocation, List<ItemStack>>.Empty;
+        }
+
+        private static void AddRecipeProcessesInto<T>(ICoreClientAPI capi, IReadOnlyList<IVEMachineRecipeBase<T>> recipes,
+                          string processesIntoVerb,
+                          ActionConsumable<string> openDetailPageFor, ItemStack stack,
+                          List<RichTextComponentBase> components, ref bool haveText)
+        {
+            IReadOnlyDictionary<AssetLocation, List<ItemStack>> groupedOutputs = GetOutputsForIngredient(recipes, stack);
+            if (groupedOutputs.Count == 0)
+            {
+                return;
+            }
+            CollectibleBehaviorHandbookTextAndExtraInfoPatch.AddHeading(components, capi, processesIntoVerb, ref haveText);
+
+            foreach (List<ItemStack> group in groupedOutputs.Values)
+            {
+                SlideshowItemstackTextComponent output =
+                    new(capi, group.ToArray(),
+                        GuiStyle.LargeFontSize, EnumFloat.Inline,
+                        (ingredient) =>
+                            openDetailPageFor(GuiHandbookItemStackPage.PageCodeForStack(
+                                ingredient)))
+                    { ShowStackSize = true };
+                components.Add(output);
+            };
+            // Add a newline
+            components.Add(new ClearFloatTextComponent(capi, CollectibleBehaviorHandbookTextAndExtraInfoPatch.MarginBottom));
+        }
+
+        private void AddRecipeCreatedBy<T>(ICoreClientAPI capi, IReadOnlyList<IVEMachineRecipeBase<T>> recipes,
+                                           string requiredMachine, string createdByVerb,
+                                           ItemStack[] allStacks, ActionConsumable<string> openDetailPageFor,
+                                           ItemStack stack, ref List<RichTextComponentBase> components)
+        {
+            IReadOnlyDictionary<AssetLocation, List<ItemStack>> groupedInputs = GetIngredientsForOutput(capi, recipes, stack, allStacks);
+            if (groupedInputs.Count == 0)
+            {
+                return;
+            }
+            if (components == null)
+            {
+                components = new();
+            }
+            else
+            {
+                components.Add(new ClearFloatTextComponent(capi, CollectibleBehaviorHandbookTextAndExtraInfoPatch.SmallPadding));
+            }
+            CollectibleBehaviorHandbookTextAndExtraInfoPatch.AddSubHeading(components, capi, openDetailPageFor, createdByVerb, null);
+
+            bool first = true;
+            foreach (List<ItemStack> group in groupedInputs.Values)
+            {
+                if (!first)
+                {
+                    // Add a newline
+                    components.Add(new ClearFloatTextComponent(capi, CollectibleBehaviorHandbookTextAndExtraInfoPatch.SmallPadding));
+                }
+                first = false;
+                SlideshowItemstackTextComponent input =
+                    new(capi, group.ToArray(),
+                        GuiStyle.LargeFontSize, EnumFloat.Inline,
+                        (ingredient) =>
+                            openDetailPageFor(GuiHandbookItemStackPage.PageCodeForStack(
+                                ingredient)))
+                    { ShowStackSize = true };
+                components.Add(input);
+                if (requiredMachine != null)
+                {
+                    RichTextComponent text = new(capi, Lang.Get("vinteng:in machine"), CairoFont.WhiteSmallText())
+                    {
+                        VerticalAlign = EnumVerticalAlign.Middle
+                    };
+                    components.Add(text);
+                    ItemStack[] machineItems = Array.Empty<ItemStack>();
+                    if (recipeMachines.TryGetValue(requiredMachine, out List<Block> machineBlocks))
+                    {
+                        machineItems = machineBlocks.Select((block) => new ItemStack(block)).ToArray();
+                    }
+                    SlideshowItemstackTextComponent machines =
+                        new(capi, machineItems,
+                            GuiStyle.LargeFontSize, EnumFloat.Inline,
+                            (ingredient) =>
+                                openDetailPageFor(GuiHandbookItemStackPage.PageCodeForStack(
+                                    ingredient)))
+                        { ShowStackSize = true };
+                    components.Add(machines);
+                }
+            };
+            // Add a newline
+            components.Add(new ClearFloatTextComponent(capi, CollectibleBehaviorHandbookTextAndExtraInfoPatch.MarginBottom));
+        }
+
+        private void AddRecipesToHandbook<T>(ICoreAPI api, IReadOnlyList<IVEMachineRecipeBase<T>> recipes, string requiredMachine, string processesIntoVerb, string createdByVerb)
+        {
+            if (api.Side != EnumAppSide.Client)
+            {
+                return;
+            }
+            CollectibleBehaviorHandbookTextAndExtraInfoPatch.ProcessesInto +=
+                delegate (ICoreClientAPI capi, ActionConsumable<string> openDetailPageFor, ItemStack stack,
+                          List<RichTextComponentBase> components, ref bool haveText)
+                {
+                    AddRecipeProcessesInto(capi, recipes, processesIntoVerb, openDetailPageFor, stack, components, ref haveText);
+                };
+
+            CollectibleBehaviorHandbookTextAndExtraInfoPatch.CreatedBy +=
+                delegate (ICoreClientAPI capi, ItemStack[] allStacks, ActionConsumable<string> openDetailPageFor,
+                          ItemStack stack, ref List<RichTextComponentBase> components)
+                {
+                    AddRecipeCreatedBy(capi, recipes, requiredMachine, createdByVerb,
+                                       allStacks, openDetailPageFor, stack, ref components);
+                };
         }
     }
 }

--- a/code/VintageEngineering/VintageEngineering.csproj
+++ b/code/VintageEngineering/VintageEngineering.csproj
@@ -35,6 +35,10 @@
       <HintPath>$(VINTAGE_STORY)\Mods\VSSurvivalMod.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="0Harmony">
+      <HintPath>$(VINTAGE_STORY)/Lib/0Harmony.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/code/VintageEngineering/VintageEngineeringMod.cs
+++ b/code/VintageEngineering/VintageEngineeringMod.cs
@@ -6,6 +6,7 @@ using Vintagestory.API.Server;
 using VintageEngineering.Electrical;
 using VintageEngineering.Transport;
 using VintageEngineering.Transport.Pipes;
+using HarmonyLib;
 
 [assembly: ModInfo("VintageEngineering",
                     Authors = new string[] { "Flexible Games" },
@@ -18,21 +19,30 @@ namespace VintageEngineering
     {
         ICoreClientAPI capi;
         ICoreServerAPI sapi;
+        private Harmony harmony;
 
         public override void Start(ICoreAPI api)
         {
             base.Start(api);
+
+            string patchId = Mod.Info.ModID;
+            if (!Harmony.HasAnyPatches(patchId))
+            {
+                harmony = new Harmony(patchId);
+                harmony.PatchAll();
+            }
+
             if (api.Side == EnumAppSide.Client)
             {
                 capi = api as ICoreClientAPI;
             }
             else
             {
-                sapi = api as ICoreServerAPI;                
+                sapi = api as ICoreServerAPI;
             }
             RegisterItems(api);
             RegisterBlocks(api);
-            RegisterBlockEntities(api);            
+            RegisterBlockEntities(api);
         }
 
         public void RegisterItems(ICoreAPI api)
@@ -43,7 +53,7 @@ namespace VintageEngineering
         public void RegisterBlocks(ICoreAPI api)
         {
             // generic electric block, can be used for most machines
-            api.RegisterBlockClass("VEElectricBlock", typeof(ElectricBlock)); 
+            api.RegisterBlockClass("VEElectricBlock", typeof(ElectricBlock));
 
             // LVGenerator has neighbor side power distribution
             api.RegisterBlockClass("VELVGenerator", typeof(BlockLVGenerator));
@@ -73,6 +83,12 @@ namespace VintageEngineering
 
             api.RegisterBlockEntityClass("VEBEItemPipe", typeof(BEPipeItem));
             //api.RegisterBlockEntityClass("VEBEFluidPipe", typeof(BEPipeFluid));
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            harmony?.UnpatchAll(harmony.Id);
         }
     }
 

--- a/mod/assets/vinteng/blocktypes/lv/vecrusher.json
+++ b/mod/assets/vinteng/blocktypes/lv/vecrusher.json
@@ -42,7 +42,10 @@
                     "*-west": 90
                 }
             }
-        ]
+        ],
+        "recipeMachineByType": {
+            "*-north": [ "crusher" ]
+        }
 	},
 	"creativeinventory": { "general": ["vecrusher-north"], "terrain": ["*"], "mechanics": ["*"] },
 	"shapeByType": {

--- a/mod/assets/vinteng/blocktypes/lv/veextruder.json
+++ b/mod/assets/vinteng/blocktypes/lv/veextruder.json
@@ -41,7 +41,10 @@
                     "*-west": 90
                 }
             }
-        ]
+        ],
+        "recipeMachineByType": {
+            "*-north": [ "extruder" ]
+        }
 	},
 	"creativeinventory": { "general": ["veextruder-north"], "terrain": ["*"], "mechanics": ["*"] },
 	"shapeByType": {

--- a/mod/assets/vinteng/blocktypes/lv/vekiln.json
+++ b/mod/assets/vinteng/blocktypes/lv/vekiln.json
@@ -40,7 +40,10 @@
                     "*-west": 90
                 }
             }
-        ]
+        ],
+        "recipeMachineByType": {
+            "*-north": [ "kiln" ]
+        }
 	},
 	"creativeinventory": { "general": ["vekiln-north"], "terrain": ["*"], "mechanics": ["*"] },
 	"shapeByType": {

--- a/mod/assets/vinteng/blocktypes/lv/velogsplitter.json
+++ b/mod/assets/vinteng/blocktypes/lv/velogsplitter.json
@@ -41,7 +41,10 @@
                     "*-west": 90
                 }
             }
-        ]
+        ],
+        "recipeMachineByType": {
+            "*-north": [ "logsplitter" ]
+        }
 	},
 	"creativeinventory": { "general": ["velogsplitter-north"], "terrain": ["*"], "mechanics": ["*"] },
 	"shapeByType": {

--- a/mod/assets/vinteng/blocktypes/lv/vemetalpress.json
+++ b/mod/assets/vinteng/blocktypes/lv/vemetalpress.json
@@ -41,7 +41,10 @@
                     "*-west": 90
                 }
             }
-        ]
+        ],
+        "recipeMachineByType": {
+            "*-north": [ "metalpress" ]
+        }
 	},
 	"creativeinventory": { "general": ["vemetalpress-north"], "terrain": ["*"], "mechanics": ["*"] },
 	"shapeByType": {

--- a/mod/assets/vinteng/blocktypes/lv/vemixer.json
+++ b/mod/assets/vinteng/blocktypes/lv/vemixer.json
@@ -44,7 +44,10 @@
                     "*-west": 90
                 }
             }
-        ]
+        ],
+        "recipeMachineByType": {
+            "*-north": [ "mixer" ]
+        }
 	},
 	"creativeinventory": { "general": ["vemixer-north"], "terrain": ["*"], "mechanics": ["*"] },
 	"shapeByType": {

--- a/mod/assets/vinteng/blocktypes/lv/vesawmill.json
+++ b/mod/assets/vinteng/blocktypes/lv/vesawmill.json
@@ -41,7 +41,10 @@
                     "*-west": 90
                 }
             }
-        ]
+        ],
+        "recipeMachineByType": {
+            "*-north": [ "sawmill" ]
+        }
 	},
 	"creativeinventory": { "general": ["vesawmill-north"], "terrain": ["*"], "mechanics": ["*"] },
 	"shapeByType": {

--- a/mod/assets/vinteng/lang/en.json
+++ b/mod/assets/vinteng/lang/en.json
@@ -186,6 +186,20 @@
 	"vinteng:item-vepipeupgrade-iron": "Iron Pipe Upgrade (Tier3)",
 	"vinteng:item-vepipeupgrade-cupronickel": "Cupronickel Pipe Upgrade (Tier4)",
 	"vinteng:item-vepipeupgrade-steel": "Steel Pipe Upgrade (Tier5)",
-	"vinteng:itemdesc-vepipeupgrade-*": "Pipe upgrade defines extraction rate and node features."
-
+	"vinteng:itemdesc-vepipeupgrade-*": "Pipe upgrade defines extraction rate and node features.",
+	"vinteng:in machine": " in machine ",
+	"vinteng:Industrially crushes into": "Industrially crushes into",
+	"vinteng:Industrially crushing": "Industrially crushing",
+	"vinteng:Presses into": "Presses into",
+	"vinteng:Pressing": "Pressing",
+	"vinteng:Splits into": "Splits into",
+	"vinteng:Splitting": "Splitting",
+	"vinteng:Saws into": "Saws into",
+	"vinteng:Sawing": "Sawing",
+	"vinteng:Extrudes into": "Extrudes into",
+	"vinteng:Extruding": "Extruding",
+	"vinteng:Industrially fires into": "Industrially fires into",
+	"vinteng:Industrially firing": "Industrially firing",
+	"vinteng:Industrially mixes into": "Industrially mixes into",
+	"vinteng:Industrially mixing": "Industrially mixing"
 }


### PR DESCRIPTION
1. Add recipes to the pages for the input ingredients.
2. Add recipes to the pages for the recipe outputs.
3. Simplify the ingredient matching logic for some recipes, because SatisfiesAsIngredient already checks the stack size.

This screenshot shows the metal plate as both an input and an output. When the screenshot was taken, the mouse was hovering over the metal press icon, which is why its hover card is shown.
![image](https://github.com/FlexibleGames/VintageEngineering/assets/21202621/0de4a3e3-85e2-4fe5-a289-b555afe9c9d6)

To avoid cluttering the pages, the required machine is only shown in the created by section.

If the recipe has multiple inputs or outputs, the slideshow shows them one by one. It's a little confusing, but I can't think of a better way to show it. The handbook also doesn't show the other required item for the machine, such as the metal mold.