### PR TITLE
Fixes for 0.5.2 push to release 0.5.3

### DIFF
--- a/code/VintageEngineering/VintageEngineering.csproj
+++ b/code/VintageEngineering/VintageEngineering.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <Version>0.5.2</Version>
+    <Version>0.5.3</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/code/VintageEngineering/inventory/InvLVFridge.cs
+++ b/code/VintageEngineering/inventory/InvLVFridge.cs
@@ -12,12 +12,22 @@ namespace VintageEngineering.inventory
 
         public InvLVFridge() : base(null)
         {
+            this.baseWeight = 3f;
             // Empty, MUST initialize!
         }
         public InvLVFridge(string inventoryID, int numSlots, ICoreAPI api, BELVFridge fridge) : base(numSlots, inventoryID, api)
         {
             slots = GenEmptySlots(numSlots);
             _fridgeBE = fridge;
+        }
+
+        public override float GetSuitability(ItemSlot sourceSlot, ItemSlot targetSlot, bool isMerge)
+        {
+            if (sourceSlot != null && !sourceSlot.Empty && (sourceSlot.Itemstack.Attributes.HasAttribute("transitionstate") || sourceSlot.Itemstack.Collectible.CanSpoil(sourceSlot.Itemstack)))
+            {
+                return this.baseWeight + 4f;
+            }
+            else return this.baseWeight - 2f;
         }
 
         public void Initialize(int numSlots, BELVFridge fridge)

--- a/mod/VintageEngineering.deps.json
+++ b/mod/VintageEngineering.deps.json
@@ -6,7 +6,7 @@
   "compilationOptions": {},
   "targets": {
     ".NETCoreApp,Version=v8.0": {
-      "VintageEngineering/0.5.2": {
+      "VintageEngineering/0.5.3": {
         "runtime": {
           "VintageEngineering.dll": {}
         }
@@ -14,7 +14,7 @@
     }
   },
   "libraries": {
-    "VintageEngineering/0.5.2": {
+    "VintageEngineering/0.5.3": {
       "type": "project",
       "serviceable": false,
       "sha512": ""

--- a/mod/assets/vinteng/recipes/grid/rotor-mv.json
+++ b/mod/assets/vinteng/recipes/grid/rotor-mv.json
@@ -3,7 +3,7 @@
 	"ingredients": {
 		"R": {
 			"type": "item",
-			"code": "vinteng:metalrod-*",
+			"code": "vinteng:metalbar-*",
 			"allowedVariants": ["iron", "steel"],
 			"quantity": 2
 		},

--- a/mod/assets/vinteng/recipes/smithing/part/vediecast-bar.json
+++ b/mod/assets/vinteng/recipes/smithing/part/vediecast-bar.json
@@ -4,13 +4,13 @@
 	"pattern": [
 		[
 			"#######",
-			"#     #",
-			"#     #",
-			"#     #",
-			"#     #",
-			"#     #",
+			"#######",
+			"##   ##",
+			"##   ##",
+			"##   ##",
+			"#######",
 			"#######"
 		]
 	],
-	"output": { "type": "item", "code": "vinteng:vediecast-rod-{metal}"  }
+	"output": { "type": "item", "code": "vinteng:vediecast-bar-{metal}"  }
 }

--- a/mod/modinfo.json
+++ b/mod/modinfo.json
@@ -5,5 +5,5 @@
   "authors": [ "Flexible Games" ],
   "description": "Extending End-Game content with machines and electricity. Includes an API to enable other modders to use the power system.",
   "website": "https://www.youtube.com/c/FlexibleGames",
-  "version": "0.5.1"
+  "version": "0.5.3"
 }


### PR DESCRIPTION
Fixes a couple forgotten areas for the metal bar change, I had a feeling I missed one or two places... sorry.

Fixes Base-game code crash regarding GetSuitability() call on Fridge inventory. Now the fridge heavily weights its inventory for things that can spoil or transition in general (Melt, Cure, Ripen, etc.).