### PR TITLE
Creative cleaning Redux: Correct branch version

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: flexiblegames
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+thanks_dev: # Replace with a single thanks.dev username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/mod/assets/game/blocktypes/wire/wire-relays.json
+++ b/mod/assets/game/blocktypes/wire/wire-relays.json
@@ -31,7 +31,7 @@
 			}
 		}
 	],
-	"creativeinventory": { "general": ["*"], "construction": ["*"],"vinteng": ["*-*-up"] },
+	"creativeinventory": { "general": ["wirerelay-*-up"], "construction": ["wirerelay-*-up"],"vinteng": ["wirerelay-*-up"] },
 	"shapeByType": {
         "*-north":  { "base": "game:block/relays/{type}", "rotateX": 270 },
 		"*-east":   { "base": "game:block/relays/{type}", "rotateZ": 270 },

--- a/mod/assets/vinteng/blocktypes/crudeoilwell.json
+++ b/mod/assets/vinteng/blocktypes/crudeoilwell.json
@@ -24,7 +24,7 @@
 		"portionpersecond": 50000
 	},
 	"blockmaterial": "Metal",
-	"creativeinventory": { "general": ["*"] },
+	"creativeinventory": { "general": ["*"],"vinteng": ["*"] },
 	"replaceable": 0,
 	"resistance": 10000,
 	"requiredMiningTier": 50,

--- a/mod/assets/vinteng/blocktypes/liquid/crudeoil.json
+++ b/mod/assets/vinteng/blocktypes/liquid/crudeoil.json
@@ -62,7 +62,11 @@
 	"liquidCode": "crudeoil",
 	"snowCoverage": false,
 	"materialdensity": 3000,
-	"creativeinventory": { "general": ["vinteng:crudeoil-still-7"], "terrain": ["vinteng:crudeoil-still-7"] },
+	"creativeinventory": {
+		"general": ["*-still-7"],
+		"terrain": ["*-still-7"],
+		"vinteng": ["*-still-7"]
+	},
 	"replaceable": 9500,
 	"lightAbsorption": 99,
 	"vertexFlags": {

--- a/mod/assets/vinteng/blocktypes/lv/lvgenerator.json
+++ b/mod/assets/vinteng/blocktypes/lv/lvgenerator.json
@@ -52,7 +52,7 @@
             }
         ]
 	},
-	"creativeinventory": { "general": ["*-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng":["*-north"] },
+	"creativeinventory": { "general": ["*-north"], "terrain": ["*-north"], "mechanics": ["*-north"], "vinteng":["*-north"] },
 	"shapeByType": {
 		"*-north": { "base": "vinteng:block/lv/generator", "rotateY":0 },
 		"*-east": { "base": "vinteng:block/lv/generator", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/lv/veblastfurnace.json
+++ b/mod/assets/vinteng/blocktypes/lv/veblastfurnace.json
@@ -34,7 +34,7 @@
         }
 	},
 	"shapeinventory": { "base": "block/lv/blastfurnace-inventory" },
-	"creativeinventory": { "general": ["veblastfurnace-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["veblastfurnace-north"] },
+	"creativeinventory": { "general": ["veblastfurnace-north"], "terrain": ["*-north"], "mechanics": ["*-north"], "vinteng": ["veblastfurnace-north"] },
 	"shapeByType": {
 		"*-north": 	{ "base": "vinteng:block/lv/blastfurnace", "rotateY":0 },
 		"*-east": 	{ "base": "vinteng:block/lv/blastfurnace", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/lv/veblower.json
+++ b/mod/assets/vinteng/blocktypes/lv/veblower.json
@@ -52,7 +52,7 @@
             }
         ]
 	},
-	"creativeinventory": { "general": ["veblower-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["veblower-north"]},
+	"creativeinventory": { "general": ["veblower-north"], "terrain": ["*-north"], "mechanics": ["*-north"], "vinteng": ["veblower-north"]},
 	"shapeByType": {
 		"*-north": 	{ "base": "vinteng:block/lv/blower", "rotateY":0 },
 		"*-east": 	{ "base": "vinteng:block/lv/blower", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/lv/vecnc.json
+++ b/mod/assets/vinteng/blocktypes/lv/vecnc.json
@@ -53,7 +53,7 @@
             }
         ]
 	},
-	"creativeinventory": { "general": ["vecnc-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["*-north"] },
+	"creativeinventory": { "general": ["vecnc-north"], "terrain": ["*-north"], "mechanics": ["*-north"], "vinteng": ["*-north"] },
 	"shapeByType": {
 		"*-north": 	{ "base": "vinteng:block/lv/cnc", "rotateY":0 },
 		"*-east": 	{ "base": "vinteng:block/lv/cnc", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/lv/vecreosoteoven.json
+++ b/mod/assets/vinteng/blocktypes/lv/vecreosoteoven.json
@@ -38,7 +38,7 @@
         }
 	},
 	"shapeinventory": { "base": "block/multiblock/machine/creosoteoven-core" },
-	"creativeinventory": { "general": ["vecreosoteoven-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["*-north"] },
+	"creativeinventory": { "general": ["vecreosoteoven-north"], "terrain": ["*-north"], "mechanics": ["*-north"], "vinteng": ["*-north"] },
 	"shapeByType": {
 		"*-north": 	{ "base": "vinteng:block/multiblock/machine/creosoteoven", "rotateY":0 },
 		"*-east": 	{ "base": "vinteng:block/multiblock/machine/creosoteoven", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/lv/vecrusher.json
+++ b/mod/assets/vinteng/blocktypes/lv/vecrusher.json
@@ -56,7 +56,7 @@
             "*-north": [ "crusher" ]
         }
 	},
-	"creativeinventory": { "general": ["vecrusher-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["*-north"]},
+	"creativeinventory": { "general": ["vecrusher-north"], "terrain": ["*-north"], "mechanics": ["*-north"], "vinteng": ["*-north"]},
 	"shapeByType": {
 		"*-north": 	{ "base": "vinteng:block/lv/crusher", "rotateY":0 },
 		"*-east": 	{ "base": "vinteng:block/lv/crusher", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/lv/veextruder.json
+++ b/mod/assets/vinteng/blocktypes/lv/veextruder.json
@@ -55,7 +55,7 @@
             "*-north": [ "extruder" ]
         }
 	},
-	"creativeinventory": { "general": ["veextruder-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["*-north"] },
+	"creativeinventory": { "general": ["veextruder-north"], "terrain": ["*-north"], "mechanics": ["*-north"], "vinteng": ["*-north"] },
 	"shapeByType": {
 		"*-north": 	{ "base": "vinteng:block/lv/extruder", "rotateY":0 },
 		"*-east": 	{ "base": "vinteng:block/lv/extruder", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/lv/veforge.json
+++ b/mod/assets/vinteng/blocktypes/lv/veforge.json
@@ -51,7 +51,7 @@
             }
         ]
 	},
-	"creativeinventory": { "general": ["veforge-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["*-north"] },
+	"creativeinventory": { "general": ["veforge-north"], "terrain": ["*-north"], "mechanics": ["*-north"], "vinteng": ["*-north"] },
 	"shapeByType": {
 		"*-north": 	{ "base": "vinteng:block/lv/forge", "rotateY":0 },
 		"*-east": 	{ "base": "vinteng:block/lv/forge", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/lv/vekiln.json
+++ b/mod/assets/vinteng/blocktypes/lv/vekiln.json
@@ -54,7 +54,7 @@
             "*-north": [ "kiln" ]
         }
 	},
-	"creativeinventory": { "general": ["vekiln-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["*-north"] },
+	"creativeinventory": { "general": ["vekiln-north"], "terrain": ["*-north"], "mechanics": ["*-north"], "vinteng": ["*-north"] },
 	"shapeByType": {
 		"*-north": 	{ "base": "vinteng:block/lv/electrickiln", "rotateY":0 },
 		"*-east": 	{ "base": "vinteng:block/lv/electrickiln", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/lv/velogsplitter.json
+++ b/mod/assets/vinteng/blocktypes/lv/velogsplitter.json
@@ -55,7 +55,7 @@
             "*-north": [ "logsplitter" ]
         }
 	},
-	"creativeinventory": { "general": ["velogsplitter-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["*-north"] },
+	"creativeinventory": { "general": ["velogsplitter-north"], "terrain": ["*-north"], "mechanics": ["*-north"], "vinteng": ["*-north"] },
 	"shapeByType": {
 		"*-north": 	{ "base": "vinteng:block/lv/logsplitter", "rotateY":0 },
 		"*-east": 	{ "base": "vinteng:block/lv/logsplitter", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/lv/velvcharger.json
+++ b/mod/assets/vinteng/blocktypes/lv/velvcharger.json
@@ -51,7 +51,7 @@
             }
         ]
 	},
-	"creativeinventory": { "general": ["velvcharger-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["*-north"] },
+	"creativeinventory": { "general": ["velvcharger-north"], "terrain": ["*-north"], "mechanics": ["*-north"], "vinteng": ["*-north"] },
 	"shapeByType": {
 		"*-north": 	{ "base": "vinteng:block/lv/lvcharger", "rotateY":0 },
 		"*-east": 	{ "base": "vinteng:block/lv/lvcharger", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/lv/velvfridge.json
+++ b/mod/assets/vinteng/blocktypes/lv/velvfridge.json
@@ -59,7 +59,7 @@
 		"spoilrate": { "powered": 0.2, "unpowered": 2.0 }
 	},
 	"shapeinventory": { "base": "block/lv/fridge" },
-	"creativeinventory": { "general": ["velvfridge-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["*-north"] },
+	"creativeinventory": { "general": ["velvfridge-north"], "terrain": ["*-north"], "mechanics": ["*-north"], "vinteng": ["*-north"] },
 	"shapeByType": {
 		"*-north": 	{ "base": "vinteng:block/lv/fridge", "rotateY":0 },
 		"*-east": 	{ "base": "vinteng:block/lv/fridge", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/lv/velvkinetic.json
+++ b/mod/assets/vinteng/blocktypes/lv/velvkinetic.json
@@ -80,7 +80,7 @@
             }
         ]
 	},
-	"creativeinventory": { "general": ["velvek-*-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["*-north"] },
+	"creativeinventory": { "general": ["velvek-*-north"], "terrain": ["*-north"], "mechanics": ["*-north"], "vinteng": ["*-north"] },
 	"shapeByType":{"*-north": { "base": "vinteng:block/lv/motor/motor-axle" },
                     "*-west": { "base": "vinteng:block/lv/motor/motor-axle","rotateY": 90 },
                     "*-south": { "base": "vinteng:block/lv/motor/motor-axle","rotateY": 180 },

--- a/mod/assets/vinteng/blocktypes/lv/vemetalpress.json
+++ b/mod/assets/vinteng/blocktypes/lv/vemetalpress.json
@@ -55,7 +55,7 @@
             "*-north": [ "metalpress" ]
         }
 	},
-	"creativeinventory": { "general": ["vemetalpress-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng":["*-north"] },
+	"creativeinventory": { "general": ["vemetalpress-north"], "terrain": ["*-north"], "mechanics": ["*-north"], "vinteng":["*-north"] },
 	"shapeByType": {
 		"*-north": 	{ "base": "vinteng:block/lv/metalpress", "rotateY":0 },
 		"*-east": 	{ "base": "vinteng:block/lv/metalpress", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/lv/vemixer.json
+++ b/mod/assets/vinteng/blocktypes/lv/vemixer.json
@@ -58,7 +58,7 @@
             "*-north": [ "mixer" ]
         }
 	},
-	"creativeinventory": { "general": ["vemixer-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng":["*-north"] },
+	"creativeinventory": { "general": ["vemixer-north"], "terrain": ["*-north"], "mechanics": ["*-north"], "vinteng":["*-north"] },
 	"shapeByType": {
 		"*-north": 	{ "base": "vinteng:block/lv/mixer", "rotateY":0 },
 		"*-east": 	{ "base": "vinteng:block/lv/mixer", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/lv/vesawmill.json
+++ b/mod/assets/vinteng/blocktypes/lv/vesawmill.json
@@ -55,7 +55,7 @@
             "*-north": [ "sawmill" ]
         }
 	},
-	"creativeinventory": { "general": ["vesawmill-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["*-north"] },
+	"creativeinventory": { "general": ["vesawmill-north"], "terrain": ["*-north"], "mechanics": ["*-north"], "vinteng": ["*-north"] },
 	"shapeByType": {
 		"*-north": 	{ "base": "vinteng:block/lv/sawmill", "rotateY":0 },
 		"*-east": 	{ "base": "vinteng:block/lv/sawmill", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/multiblock/mbpowerconnectors.json
+++ b/mod/assets/vinteng/blocktypes/multiblock/mbpowerconnectors.json
@@ -31,7 +31,7 @@
 			}
 		}
 	],
-	"creativeinventory": { "general": ["*"], "construction": ["*"],"vinteng": ["*-*-up"] },
+	"creativeinventory": { "general": ["*-up"], "construction": ["*-up"],"vinteng": ["*-*-up"] },
 	"shapeByType": {
         "*-north":  { "base": "vinteng:block/connectors/{type}", "rotateX": 270 },
 		"*-east":   { "base": "vinteng:block/connectors/{type}", "rotateZ": 270 },

--- a/mod/assets/vinteng/blocktypes/multiblock/vembcreosoteoven.json
+++ b/mod/assets/vinteng/blocktypes/multiblock/vembcreosoteoven.json
@@ -101,7 +101,7 @@
         }
 	},
 	"shapeinventory": { "base": "block/multiblock/machine/creosoteoven-core" },
-	"creativeinventory": { "general": ["vembcreosoteoven-incomplete-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["*-incomplete-north"] },
+	"creativeinventory": { "general": ["vembcreosoteoven-incomplete-north"], "terrain": ["*-incomplete-north"], "mechanics": ["*-incomplete-north"], "vinteng": ["*-incomplete-north"] },
 	"shapeByType": {
 		"*-incomplete-north": 	{ "base": "vinteng:block/multiblock/machine/creosoteoven-core", "rotateY":0 },
 		"*-incomplete-east": 	{ "base": "vinteng:block/multiblock/machine/creosoteoven-core", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/multiblock/vembderrick.json
+++ b/mod/assets/vinteng/blocktypes/multiblock/vembderrick.json
@@ -251,7 +251,7 @@
 		"wellCasingCode": "vinteng:wellcasing"
 	},
 	"shapeinventory": { "base": "block/multiblock/machine/derrick-core" },
-	"creativeinventory": { "general": ["vembderrick"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["*-incomplete-north"] },
+	"creativeinventory": { "general": ["*-incomplete-north"], "terrain": ["*-incomplete-north"], "mechanics": ["*-incomplete-north"], "vinteng": ["*-incomplete-north"] },
 	"shapeByType": {
 		"*-incomplete-north": 	{ "base": "vinteng:block/multiblock/machine/derrick-core", "rotateY":0 },
 		"*-incomplete-east": 	{ "base": "vinteng:block/multiblock/machine/derrick-core", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/multiblock/vembdistillationbase.json
+++ b/mod/assets/vinteng/blocktypes/multiblock/vembdistillationbase.json
@@ -60,7 +60,7 @@
         }
 	},
 	"shapeinventory": { "base": "block/multiblock/machine/distillationbase-core" },
-	"creativeinventory": { "general": ["vembdistillationbase"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["*-incomplete-north"] },
+	"creativeinventory": { "general": ["*-incomplete-north"], "terrain": ["*-incomplete-north"], "mechanics": ["*-incomplete-north"], "vinteng": ["*-incomplete-north"] },
 	"shapeByType": {
 		"*-incomplete-north": 	{ "base": "vinteng:block/multiblock/machine/distillationbase-core", "rotateY":0 },
 		"*-incomplete-east": 	{ "base": "vinteng:block/multiblock/machine/distillationbase-core", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/multiblock/vembdistillationext.json
+++ b/mod/assets/vinteng/blocktypes/multiblock/vembdistillationext.json
@@ -55,7 +55,7 @@
 		"fluidCapacityLiters": 2000
 	},
 	"shapeinventory": { "base": "block/multiblock/machine/distillationext-core" },
-	"creativeinventory": { "general": ["vembdistillationext"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["*-incomplete-north"] },
+	"creativeinventory": { "general": ["*-incomplete-north"], "terrain": ["*-incomplete-north"], "mechanics": ["*-incomplete-north"], "vinteng": ["*-incomplete-north"] },
 	"shapeByType": {
 		"*-incomplete-north": 	{ "base": "vinteng:block/multiblock/machine/distillationext-core", "rotateY":0 },
 		"*-incomplete-east": 	{ "base": "vinteng:block/multiblock/machine/distillationext-core", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/multiblock/vembpumpjack.json
+++ b/mod/assets/vinteng/blocktypes/multiblock/vembpumpjack.json
@@ -105,7 +105,7 @@
 		"wellCasingCode": "vinteng:wellcasing"
 	},
 	"shapeinventory": { "base": "block/multiblock/machine/pumpjack-core" },
-	"creativeinventory": { "general": ["vembpumpjack-incomplete-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["*-incomplete-north"] },
+	"creativeinventory": { "general": ["vembpumpjack-incomplete-north"], "terrain": ["*-incomplete-north"], "mechanics": ["*-incomplete-north"], "vinteng": ["*-incomplete-north"] },
 	"shapeByType": {
 		"*-incomplete-north": 	{ "base": "vinteng:block/multiblock/machine/pumpjack-core", "rotateY":0 },
 		"*-incomplete-east": 	{ "base": "vinteng:block/multiblock/machine/pumpjack-core", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/multiblock/vembpumpjack.json
+++ b/mod/assets/vinteng/blocktypes/multiblock/vembpumpjack.json
@@ -105,7 +105,7 @@
 		"wellCasingCode": "vinteng:wellcasing"
 	},
 	"shapeinventory": { "base": "block/multiblock/machine/pumpjack-core" },
-	"creativeinventory": { "general": ["vembpumpjack-incomplete-north"], "terrain": ["*-incomplete-north"], "mechanics": ["*-incomplete-north"], "vinteng": ["*-incomplete-north"] },
+	"creativeinventory": { "general": ["*-incomplete-north"], "terrain": ["*-incomplete-north"], "mechanics": ["*-incomplete-north"], "vinteng": ["*-incomplete-north"] },
 	"shapeByType": {
 		"*-incomplete-north": 	{ "base": "vinteng:block/multiblock/machine/pumpjack-core", "rotateY":0 },
 		"*-incomplete-east": 	{ "base": "vinteng:block/multiblock/machine/pumpjack-core", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/mv/vemvtransformer.json
+++ b/mod/assets/vinteng/blocktypes/mv/vemvtransformer.json
@@ -70,7 +70,7 @@
             }
         ]
 	},
-	"creativeinventory": { "general": ["vemvtransformer-north"], "terrain": ["*"], "mechanics": ["*"], "vinteng": ["vemvtransformer-north"]},
+	"creativeinventory": { "general": ["vemvtransformer-north"], "terrain": ["*-north"], "mechanics": ["*-north"], "vinteng": ["vemvtransformer-north"]},
 	"shapeByType": {
 		"*-north": 	{ "base": "vinteng:block/mvlvtransformer", "rotateY":0 },
 		"*-east": 	{ "base": "vinteng:block/mvlvtransformer", "rotateY":270 },

--- a/mod/assets/vinteng/blocktypes/pipes/pipeconnections.json
+++ b/mod/assets/vinteng/blocktypes/pipes/pipeconnections.json
@@ -15,7 +15,6 @@
 						"west": { "x1": 7, "y1": 7, "z1": 0, "x2": 8, "y2": 8, "z2": 1, "rotateY": 270 }
 					}
 					}}],
-	"creativeinventory": { "general": ["*"], "construction": ["*"] },
 	"shapeByType": {
         "*-north":  { "base": "vinteng:block/pipes/{type}", "rotateX": 90 },
 		"*-east":   { "base": "vinteng:block/pipes/{type}", "rotateZ": 90 },

--- a/mod/assets/vinteng/blocktypes/pipes/well-casing.json
+++ b/mod/assets/vinteng/blocktypes/pipes/well-casing.json
@@ -1,13 +1,14 @@
 {
 	"code": "wellcasing",
 	"creativeinventory": {
-		"vinteng-decor": [ "*" ]
+		"vinteng": [ "*" ]
 	},
 	"maxStackSize": 50,
 	"blockmaterial": "Stone",
 	"drawtype": "json",
 	"shape": { "base": "block/pipes/well-casing" },
 	"resistance": 1,
+
 	"sideSolid": { "all": true },
 	"sideOpaque": {"all": false },
 	"sounds": {


### PR DESCRIPTION
Cleans up the creative menu blocks to only include the "survival" obtainable block or the "Inactive" block for multiblocks.

This significantly reduces the amount of bloat in the vanilla CM tabs, and also removes some blocks that *shouldnt* be placed on their own from the CM.